### PR TITLE
fix(exos-scripts): [Build] Improve error and warning messages

### DIFF
--- a/packages/exos-scripts/src/scripts/build/index.ts
+++ b/packages/exos-scripts/src/scripts/build/index.ts
@@ -18,7 +18,10 @@ const compiler = webpack(configToUse.config);
 compiler.run((err: Error, stats: webpack.Stats) => {
   // The err object will only contain webpack-related issues, such as misconfiguration, etc.
   // Compilation errors are stored in stats.hasErrors()
+
   if (err) {
+    console.log();
+    console.error(chalk.red("❌ There are compilation errors. Fix them and try again."));
     console.error(err.message);
     console.error(err.stack || err);
     console.log();
@@ -28,18 +31,23 @@ compiler.run((err: Error, stats: webpack.Stats) => {
   const executionStats = stats.toJson({ all: false, warnings: true, errors: true });
 
   if (executionStats.errors.length) {
-    // Only keep the first error. Others are often indicative
-    // of the same problem, but confuse the reader with noise.
+    // Only print the first error. Others are often indicative
+    // of the same problem, and the extra noise will confuse the reader.
+    console.log();
     console.error(chalk.red("❌ There was an error during build."));
     console.error(executionStats.errors[0]);
-    console.log();
+
+    // Exit with a fail code
     process.exit(1);
   }
 
   if (stats.hasWarnings()) {
-    console.warn(chalk.yellow("🚧 There were warnings during build."));
-    console.warn(executionStats.warnings);
+    // Print all the warnings, but don't fail
     console.log();
+    console.warn(chalk.yellow("🚧 There were warnings during build."));
+    executionStats.warnings.forEach((warning) => console.warn(chalk.yellow(warning)));
+
+    // Exit with an OK code
     process.exit(0);
   }
 

--- a/packages/exos-scripts/src/scripts/build/index.ts
+++ b/packages/exos-scripts/src/scripts/build/index.ts
@@ -37,7 +37,7 @@ compiler.run((err: Error, stats: webpack.Stats) => {
     console.error(chalk.red("❌ There was an error during build."));
     console.error(executionStats.errors[0]);
 
-    // Exit with a fail code
+    // Exit with a failure code
     process.exit(1);
   }
 


### PR DESCRIPTION
This PR improves the error messages displayed in the console, both _warnings_ and _errors_.

![image](https://user-images.githubusercontent.com/1306634/83768774-95919b00-a655-11ea-8495-976881e577dd.png)
